### PR TITLE
feat: user end date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatbot-back",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatbot-back",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "MIT",
       "dependencies": {
         "@nestjs-modules/mailer": "^1.8.1",

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -109,8 +109,8 @@ export class AuthService {
    */
   private async _validateUser(user: LoginUserDto): Promise<any> {
     const userToReturn = await this._userService.findOne(user.email, true);
-    const now = Date.now();
-    if (userToReturn && userToReturn.end_date < now) {
+    const now = new Date();
+    if (userToReturn?.end_date && userToReturn.end_date < now) {
       throw new HttpException('Votre compte n\'est plus actif. Merci de prendre contact avec l\'administrateur si vous souhaitez réactiver votre compte.',
         HttpStatus.UNAUTHORIZED);
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -17,8 +17,8 @@ export class AuthService {
   private _failedLoginAttempts = 5;
 
   constructor(private readonly _userService: UserService,
-              private readonly _jwtService: JwtService,
-              private readonly _mailService: MailService) {
+    private readonly _jwtService: JwtService,
+    private readonly _mailService: MailService) {
   }
 
   /**
@@ -109,18 +109,23 @@ export class AuthService {
    */
   private async _validateUser(user: LoginUserDto): Promise<any> {
     const userToReturn = await this._userService.findOne(user.email, true);
+    const now = Date.now();
+    if (userToReturn && userToReturn.end_date < now) {
+      throw new HttpException('Votre compte n\'est plus actif. Merci de prendre contact avec l\'administrateur si vous souhaitez réactiver votre compte.',
+        HttpStatus.UNAUTHORIZED);
+    }
     if (userToReturn && userToReturn.disabled) {
       throw new HttpException('Votre compte a été supprimé. Merci de prendre contact avec l\'administrateur si vous souhaitez réactiver votre compte.',
         HttpStatus.UNAUTHORIZED);
     }
     if (userToReturn && userToReturn.lock_until && moment.duration(moment(userToReturn.lock_until).add(1, 'd').diff(moment())).asHours() < 0) {
-      await this._userService.findAndUpdate(userToReturn.email, {failed_login_attempts: 0, lock_until: null});
+      await this._userService.findAndUpdate(userToReturn.email, { failed_login_attempts: 0, lock_until: null });
       userToReturn.lock_until = null;
       userToReturn.failed_login_attempts = 0;
     }
     if (userToReturn && userToReturn.password && bcrypt.compareSync(user.password, userToReturn.password) && userToReturn.failed_login_attempts < this._failedLoginAttempts) {
-      const {password, ...result} = userToReturn;
-      await this._userService.findAndUpdate(userToReturn.email, {failed_login_attempts: 0, lock_until: null})
+      const { password, ...result } = userToReturn;
+      await this._userService.findAndUpdate(userToReturn.email, { failed_login_attempts: 0, lock_until: null })
       return result;
     }
     if (userToReturn && userToReturn.password && (!bcrypt.compareSync(user.password, userToReturn.password) || userToReturn.failed_login_attempts >= this._failedLoginAttempts)) {

--- a/src/core/dto/create-user.dto.ts
+++ b/src/core/dto/create-user.dto.ts
@@ -27,6 +27,6 @@ export class CreateUserDto {
   password: string;
 
   @IsDateString()
-  @IsNotEmpty()
+  @IsOptional()
   endDate: string;
 }

--- a/src/core/dto/create-user.dto.ts
+++ b/src/core/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { IsDateString, IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString } from "class-validator";
 import { UserRole } from "@core/enums/user-role.enum";
 
 export class CreateUserDto {
@@ -25,4 +25,8 @@ export class CreateUserDto {
   @IsString()
   @IsOptional()
   password: string;
+
+  @IsDateString()
+  @IsNotEmpty()
+  endDate: string;
 }

--- a/src/core/dto/update-user.dto.ts
+++ b/src/core/dto/update-user.dto.ts
@@ -23,6 +23,6 @@ export class UpdateUserDto {
   role: UserRole;
 
   @IsDateString()
-  @IsNotEmpty()
+  @IsOptional()
   endDate: string;
 }

--- a/src/core/dto/update-user.dto.ts
+++ b/src/core/dto/update-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsEnum, IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { IsBoolean, IsDateString, IsEnum, IsNotEmpty, IsOptional, IsString } from "class-validator";
 import { UserRole } from "@core/enums/user-role.enum";
 
 export class UpdateUserDto {
@@ -21,4 +21,8 @@ export class UpdateUserDto {
   @IsEnum(UserRole)
   @IsOptional()
   role: UserRole;
+
+  @IsDateString()
+  @IsNotEmpty()
+  endDate: string;
 }

--- a/src/core/dto/user.dto.ts
+++ b/src/core/dto/user.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsNotEmpty, IsString } from 'class-validator';
+import { IsDateString, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { UserRole } from "@core/enums/user-role.enum";
 
 export class UserDto {
@@ -18,6 +18,6 @@ export class UserDto {
   role: UserRole;
 
   @IsDateString()
-  @IsNotEmpty()
+  @IsOptional()
   endDate: string;
 }

--- a/src/core/dto/user.dto.ts
+++ b/src/core/dto/user.dto.ts
@@ -1,4 +1,4 @@
-import { IsString } from 'class-validator';
+import { IsDateString, IsNotEmpty, IsString } from 'class-validator';
 import { UserRole } from "@core/enums/user-role.enum";
 
 export class UserDto {
@@ -16,4 +16,8 @@ export class UserDto {
 
   @IsString()
   role: UserRole;
+
+  @IsDateString()
+  @IsNotEmpty()
+  endDate: string;
 }

--- a/src/core/entities/user.entity.ts
+++ b/src/core/entities/user.entity.ts
@@ -47,6 +47,6 @@ export class User {
   @Column({ default: false })
   disabled: boolean;
 
-  @Column({ type: "timestamptz" })
-  end_date: number;
+  @Column({ type: "timestamptz", nullable: true })
+  end_date: Date | null;
 }

--- a/src/core/entities/user.entity.ts
+++ b/src/core/entities/user.entity.ts
@@ -5,37 +5,37 @@ import { Intent } from "@core/entities/intent.entity";
 
 @Entity('chatbot_user')
 export class User {
-  @PrimaryColumn({nullable: false, length: 200})
+  @PrimaryColumn({ nullable: false, length: 200 })
   email: string;
 
-  @Column({select: false, nullable: true, length: 200})
+  @Column({ select: false, nullable: true, length: 200 })
   password: string;
 
-  @Column({nullable: false, default: 0})
+  @Column({ nullable: false, default: 0 })
   failed_login_attempts: number;
 
-  @Column({type: "timestamp", nullable: true})
+  @Column({ type: "timestamp", nullable: true })
   lock_until: number;
 
-  @Column({nullable: false, length: 50})
+  @Column({ nullable: false, length: 50 })
   first_name: string;
 
-  @Column({nullable: false, length: 50})
+  @Column({ nullable: false, length: 50 })
   last_name: string;
 
-  @Column({nullable: true, length: 50})
+  @Column({ nullable: true, length: 50 })
   function: string;
 
-  @Column('enum', {name: 'role', enum: UserRole, default: UserRole.reader, nullable: false})
+  @Column('enum', { name: 'role', enum: UserRole, default: UserRole.reader, nullable: false })
   role: UserRole;
 
-  @CreateDateColumn({type: "timestamp"})
+  @CreateDateColumn({ type: "timestamp" })
   created_at: number;
 
-  @Column({nullable: true, length: 255})
+  @Column({ nullable: true, length: 255 })
   reset_password_token: string;
 
-  @Column({type: "timestamp", nullable: true})
+  @Column({ type: "timestamp", nullable: true })
   reset_password_expires: number;
 
   @OneToMany(type => Inbox, inbox => inbox.user)
@@ -44,6 +44,9 @@ export class User {
   @OneToMany(type => Intent, intent => intent.user)
   intents: Intent[];
 
-  @Column({default: false})
+  @Column({ default: false })
   disabled: boolean;
+
+  @Column({ type: "timestamptz" })
+  end_date: number;
 }

--- a/src/core/models/user.model.ts
+++ b/src/core/models/user.model.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsDateString, IsEmail, IsNotEmpty, IsOptional, IsString, isDate } from 'class-validator';
 import { UserRole } from "@core/enums/user-role.enum";
 
 export class UserModel {
@@ -29,4 +29,7 @@ export class UserModel {
   @IsString()
   @IsOptional()
   password: string;
+
+  @IsDateString()
+  endDate: string;
 }

--- a/src/core/models/user.model.ts
+++ b/src/core/models/user.model.ts
@@ -31,5 +31,6 @@ export class UserModel {
   password: string;
 
   @IsDateString()
-  endDate: string;
+  @IsOptional()
+  end_date?: string;
 }

--- a/src/core/repository-utils.ts
+++ b/src/core/repository-utils.ts
@@ -1,0 +1,8 @@
+import { Repository } from "typeorm";
+
+/**
+ * Get the column names of a repository (including ones flagged as "select: false")
+ */
+export function getCols<T>(repository: Repository<T>): (keyof T)[] {
+    return (repository.metadata.columns.map(col => col.propertyName) as (keyof T)[]);
+}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -5,14 +5,15 @@ import { User } from "@core/entities/user.entity";
 import { MailService } from "../shared/services/mail.service";
 import { UserModel } from "@core/models/user.model";
 import { UserRole } from "@core/enums/user-role.enum";
+import { getCols } from '@core/repository-utils';
 const bcrypt = require('bcrypt');
 const crypto = require('crypto');
 
 @Injectable()
 export class UserService {
   constructor(@InjectRepository(User)
-              private readonly _usersRepository: Repository<User>,
-              private readonly _mailService: MailService) {
+  private readonly _usersRepository: Repository<User>,
+    private readonly _mailService: MailService) {
   }
 
   /**
@@ -33,13 +34,13 @@ export class UserService {
    * @param email
    * @param password
    */
-  findOne(email: string, password: boolean = false): Promise<User> {
+  findOne(email: string, password = false): Promise<User> {
     if (!password) {
-      return this._usersRepository.findOne({where: {email: email}});
+      return this._usersRepository.findOne({ where: { email: email } });
     }
     return this._usersRepository.findOne({
-      select: ['email', 'password', 'first_name', 'last_name', 'function', 'role', 'failed_login_attempts', 'lock_until'],
-      where: {email: email}
+      select: getCols(this._usersRepository),
+      where: { email: email }
     });
   }
 
@@ -73,7 +74,7 @@ export class UserService {
    * @param data
    */
   async update(email: string, data: any): Promise<User> {
-    await this._usersRepository.update({email: email}, data);
+    await this._usersRepository.update({ email: email }, data);
     return this.findOne(email);
   }
 
@@ -97,7 +98,7 @@ export class UserService {
    * @param email
    */
   async delete(email: string): Promise<void> {
-    await this._usersRepository.update({email: email}, {disabled: true});
+    await this._usersRepository.update({ email: email }, { disabled: true });
   }
 
   /**

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -169,11 +169,11 @@ export class UserService {
    * 3/ Si l'utilisateur n'est pas un administrateur, on ne fait rien.
    */
   private async _isOneActiveAdminLeft(editing: UserModel): Promise<boolean> {
-    const users = await this.findAll();
+    const users = await this._usersRepository.find({ where: { role: UserRole.admin } });
     for (const user of users) {
       if (user.email === editing.email && editing.role === UserRole.admin && !user.disabled && !editing.end_date) {
         return true;
-      } else if (user.email !== editing.email && user.role === UserRole.admin && !user.disabled && !user.end_date) {
+      } else if (user.email !== editing.email && !user.disabled && !user.end_date) {
         return true;
       }
     }


### PR DESCRIPTION
Closes https://github.com/fabnumdef/chatbot-front/issues/283

## Done :
- add getCols utils to get all repository columns names and update user service
- add end_date column to user entity typed as timestamptz
- add endDate as date string to create, update and default user dto
- add logic to auth service
- add control to keep at least one active admin